### PR TITLE
Enhancement: Update repository security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/* @PascalBourdier @jawher @lpereir4 @tbeaugrand

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/* @sre
+.github/* @mirakl/sre

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/* @PascalBourdier @jawher @lpereir4 @tbeaugrand
+.github/* @sre

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
       statuses: none
     steps:
       - name: Set up Go 1.16
-        # Tag v2.2.0 https://github.com/actions/setup-go/commit/bfdd3570ce990073878bf10f6b2d79082de49492
-        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492
+        # Github Action as the label "Verified creator" https://github.com/marketplace/actions/setup-go-environment
+        uses: actions/setup-go@v2
         with:
           go-version: 1.16
         id: go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,19 @@ jobs:
   build:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      actions: none
+      checks: none
+      contents: write
+      deployments: none
+      id-token: none
+      issues: none
+      packages: none
+      pages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
     steps:
       - name: Set up Go 1.16
         uses: actions/setup-go@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
       statuses: none
     steps:
       - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+        # Tag v2.2.0 https://github.com/actions/setup-go/commit/bfdd3570ce990073878bf10f6b2d79082de49492
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492
         with:
           go-version: 1.16
         id: go


### PR DESCRIPTION
Add a CODEOWNERS and reduce the GITHUB_TOKEN permissions to a minimum.
Use the commit SHA instead of the tag name.