### PR TITLE
doc: Fix import url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For KV v1:
 
 ```go
 
-import "github.com/mirakl/lib-vault/vaultv1"
+import "github.com/mirakl/lib-vault/v2/vaultv2"
 
 client, err := vaultv1.CreateClient()
 ```
@@ -21,7 +21,7 @@ For KV v2:
 
 ```go
 
-import "github.com/mirakl/lib-vault/vaultv2"
+import "github.com/mirakl/lib-vault/v2/vaultv2"
 
 client, err := vaultv2.CreateClient()
 ```


### PR DESCRIPTION
doc: Fix import url in readme 
error : 
```
❯ go install
main.go:10:8: no required module provides package github.com/mirakl/lib-vault/vaultv2; to add it:
        go get github.com/mirakl/lib-vault/vaultv2
❯ go get github.com/mirakl/lib-vault/vaultv2

go: module github.com/mirakl/lib-vault@upgrade found (v1.1.1), but does not contain package github.com/mirakl/lib-vault/vaultv2

```